### PR TITLE
Update gradio_app.py

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -30,7 +30,7 @@ import uuid
 
 from hy3dgen.shapegen.utils import logger
 
-MAX_SEED = 1e7
+MAX_SEED = int(1e7)
 
 
 def get_example_img_list():


### PR DESCRIPTION
In Python, numbers written in scientific notation (such as 1e7) are interpreted as float by default, not int. This is because scientific notation is generally used to represent floating-point numbers, and Python treats it as such.