### PR TITLE
Pin transformers so it doesn't error out with AttributeError: 'SafeTe…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ einops
 opencv-python
 numpy
 torch
-transformers
+transformers==4.49.0
 torchvision
 #taming-transformers-rom1504
 #ConfigArgParse


### PR DESCRIPTION
The latest version of transformers breaks the app with the following error:

```
'SafeTensorFile' object has no attribute 'get_slice'██████████████████████████████████████████████████████████████████████████████████████████████| 3.66G/3.66G [01:15<00:00, 123MB/s]
Failed to load texture generator.
Please try to install requirements by following README.md
Loading pipeline components...:  71%|██████████████████████████████████████████████████████████████████████████████████▏                                | 5/7 [00:24<00:09,  4.98s/it]
Traceback (most recent call last):
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\gradio_app.py", line 835, in <module>  
    t2i_worker = HunyuanDiTPipeline('Tencent-Hunyuan/HunyuanDiT-v1.1-Diffusers-Distilled')
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\hy3dgen\text2image.py", line 38, in __init__
    self.pipe = AutoPipelineForText2Image.from_pretrained(
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\huggingface_hub\utils\_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\diffusers\pipelines\auto_pipeline.py", line 428, in from_pretrained
    return text_2_image_cls.from_pretrained(pretrained_model_or_path, **kwargs)
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\huggingface_hub\utils\_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\diffusers\pipelines\pipeline_utils.py", line 924, in from_pretrained
    loaded_sub_model = load_sub_model(
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\diffusers\pipelines\pipeline_loading_utils.py", line 725, in load_sub_model
    loaded_sub_model = load_method(os.path.join(cached_folder, name), **loading_kwargs)
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\transformers\modeling_utils.py", line 272, in _wrapper
    return func(*args, **kwargs)
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\transformers\modeling_utils.py", line 4455, in from_pretrained
    ) = cls._load_pretrained_model(
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\transformers\modeling_utils.py", line 4693, in _load_pretrained_model
    load_state_dict(checkpoint_files[0], map_location="meta", weights_only=weights_only).keys()
  File "C:\pinokio\api\Hunyuan3D-2-lowvram.git\app\env\lib\site-packages\transformers\modeling_utils.py", line 564, in load_state_dict
    dtype = str_to_torch_dtype[f.get_slice(k).get_dtype()]
AttributeError: 'SafeTensorFile' object has no attribute 'get_slice'
```

Pinning the version fixes the problem.